### PR TITLE
⚙️ auto import で type import を優先するように

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,6 @@
   },
   "[mdx]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "typescript.preferences.preferTypeOnlyAutoImports": true
 }


### PR DESCRIPTION
一瞬！一瞬！一瞬！一瞬！

import suggestion から import したときに type が使えれば使ってくれるらしい

not type import してると biome で警告されるのでどうせだしね